### PR TITLE
[CLI] Improvements to the Add Function

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -32,7 +32,7 @@ pub enum Command {
 #[derive(Debug, Args)]
 pub struct AddArgs {
     /// The command to add to your stack
-    pub command: String,
+    pub command: Option<String>,
 
     /// Notes relating to the command
     #[clap(long = "note", short = 'n')]

--- a/cli/src/command/add_command.rs
+++ b/cli/src/command/add_command.rs
@@ -3,7 +3,7 @@ use crate::{
     outputs::{format_output, print_internal_command_table, spacing},
 };
 use data::models::InternalCommand;
-use inquire::{InquireError, Select, Text};
+use inquire::{min_length, InquireError, Select, Text};
 use log::error;
 use logic::Logic;
 use thiserror::Error;
@@ -12,44 +12,58 @@ use thiserror::Error;
 pub enum HandleAddError {
     #[error("Failed to get user input")]
     Inquire(#[from] InquireError),
+    #[error("Missing field: {0}")]
+    MissingField(String),
     #[error("Failed to initialize logic")]
     LogicInit(#[from] logic::LogicInitError),
     #[error("Failed to add command")]
     LogicAdd(#[from] logic::command::AddCommandError),
 }
 
-impl From<AddArgs> for InternalCommand {
-    fn from(args: AddArgs) -> Self {
-        InternalCommand {
-            command: args.command,
-            tag: args.tag,
-            note: args.note,
-            favourite: args.favourite,
+impl TryFrom<AddArgs> for InternalCommand {
+    type Error = HandleAddError;
+
+    fn try_from(args: AddArgs) -> Result<Self, Self::Error> {
+        if let Some(command) = args.command {
+            Ok(InternalCommand {
+                command,
+                tag: args.tag,
+                note: args.note,
+                favourite: args.favourite,
+            })
+        } else {
+            Err(HandleAddError::MissingField("command".to_string()))
         }
     }
 }
 
 /// Generates a wizard to set the properties of a command
-fn get_add_args_from_user(command: &str) -> Result<InternalCommand, InquireError> {
+fn get_add_args_from_user(args: AddArgs) -> Result<InternalCommand, InquireError> {
     spacing();
+    // No check needed since wizard is only displayed if the command field is not present
+    let command = Text::new(&format_output("<bold>Command:</bold>"))
+        .with_validator(min_length!(1, "Command must not be empty"))
+        .prompt()?;
 
     let tag = Text::new(&format_output(
         "<bold>Tag</bold> <italics>(Leave blank to skip)</italics><bold>:</bold>",
     ))
+    .with_initial_value(&args.tag.unwrap_or_default())
     .prompt()?;
 
     let note = Text::new(&format_output(
         "<bold>Note</bold> <italics>(Leave blank to skip)</italics><bold>:</bold>",
     ))
+    .with_initial_value(&args.note.unwrap_or_default())
     .prompt()?;
 
     let favourite = Select::new(&format_output("<bold>Favourite:</bold>"), vec!["Yes", "No"])
-        .with_starting_cursor(1)
+        .with_starting_cursor(!args.favourite as usize)
         .prompt()?
         == "Yes";
 
     Ok(InternalCommand {
-        command: String::from(command),
+        command: command,
         tag: if !tag.is_empty() { Some(tag) } else { None },
         note: if !note.is_empty() { Some(note) } else { None },
         favourite,
@@ -58,13 +72,13 @@ fn get_add_args_from_user(command: &str) -> Result<InternalCommand, InquireError
 
 /// CLI handler for the add command
 pub fn handle_add_command(args: AddArgs) -> Result<(), HandleAddError> {
-    let add_args_exist = args.tag.is_some() || args.note.is_some();
+    let add_args_exist = args.command.is_some();
 
     // Get the command to add either from CLI args or user input
-    let internal_command = if !add_args_exist {
-        get_add_args_from_user(&args.command)?
+    let internal_command = if !args.command.is_some() {
+        get_add_args_from_user(args)?
     } else {
-        InternalCommand::from(args)
+        InternalCommand::try_from(args)?
     };
 
     let logic = Logic::try_default()?;

--- a/cli/src/command/add_command.rs
+++ b/cli/src/command/add_command.rs
@@ -63,7 +63,7 @@ fn get_add_args_from_user(args: AddArgs) -> Result<InternalCommand, InquireError
         == "Yes";
 
     Ok(InternalCommand {
-        command: command,
+        command,
         tag: if !tag.is_empty() { Some(tag) } else { None },
         note: if !note.is_empty() { Some(note) } else { None },
         favourite,
@@ -75,7 +75,7 @@ pub fn handle_add_command(args: AddArgs) -> Result<(), HandleAddError> {
     let add_args_exist = args.command.is_some();
 
     // Get the command to add either from CLI args or user input
-    let internal_command = if !args.command.is_some() {
+    let internal_command = if !add_args_exist {
         get_add_args_from_user(args)?
     } else {
         InternalCommand::try_from(args)?

--- a/cli/src/command/update_command.rs
+++ b/cli/src/command/update_command.rs
@@ -7,7 +7,7 @@ use crate::{
     outputs::{format_output, Output},
 };
 use data::models::InternalCommand;
-use inquire::{InquireError, Select, Text};
+use inquire::{min_length, InquireError, Select, Text};
 use log::error;
 use logic::Logic;
 use thiserror::Error;
@@ -42,6 +42,7 @@ pub fn set_command_properties_wizard(
 ) -> Result<InternalCommand, InquireError> {
     let command = Text::new(&format_output("<bold>Command</bold>:"))
         .with_initial_value(&cur_command.command)
+        .with_validator(min_length!(1, "Command must not be empty"))
         .prompt()?;
 
     let tag = Text::new(&format_output(


### PR DESCRIPTION
An error is no longer displayed if the user does not specify  the command when running the `add` command. Additionally, put validation on the command field. 