### PR TITLE
Flag commands that only contain whitespace

### DIFF
--- a/cli/src/command/add_command.rs
+++ b/cli/src/command/add_command.rs
@@ -1,12 +1,17 @@
 use crate::{
     args::AddArgs,
     outputs::{format_output, print_internal_command_table, spacing},
+    utils::none_if_empty,
+    
 };
 use data::models::InternalCommand;
-use inquire::{min_length, InquireError, Select, Text};
+use inquire::error::InquireError;
+use inquire::{Select, Text};
 use log::error;
 use logic::Logic;
 use thiserror::Error;
+
+use super::CommandInputValidator;
 
 #[derive(Error, Debug)]
 pub enum HandleAddError {
@@ -42,7 +47,7 @@ fn get_add_args_from_user(args: AddArgs) -> Result<InternalCommand, InquireError
     spacing();
     // No check needed since wizard is only displayed if the command field is not present
     let command = Text::new(&format_output("<bold>Command:</bold>"))
-        .with_validator(min_length!(1, "Command must not be empty"))
+        .with_validator(CommandInputValidator)
         .prompt()?;
 
     let tag = Text::new(&format_output(
@@ -64,8 +69,8 @@ fn get_add_args_from_user(args: AddArgs) -> Result<InternalCommand, InquireError
 
     Ok(InternalCommand {
         command,
-        tag: if !tag.is_empty() { Some(tag) } else { None },
-        note: if !note.is_empty() { Some(note) } else { None },
+        tag: none_if_empty(tag),
+        note: none_if_empty(note),
         favourite,
     })
 }

--- a/cli/src/command/add_command.rs
+++ b/cli/src/command/add_command.rs
@@ -1,8 +1,8 @@
 use crate::{
     args::AddArgs,
+    command::CommandInputValidator,
     outputs::{format_output, print_internal_command_table, spacing},
     utils::none_if_empty,
-    
 };
 use data::models::InternalCommand;
 use inquire::error::InquireError;
@@ -10,8 +10,6 @@ use inquire::{Select, Text};
 use log::error;
 use logic::Logic;
 use thiserror::Error;
-
-use super::CommandInputValidator;
 
 #[derive(Error, Debug)]
 pub enum HandleAddError {

--- a/cli/src/command/mod.rs
+++ b/cli/src/command/mod.rs
@@ -3,3 +3,21 @@ pub mod delete_command;
 pub mod search_command;
 pub mod search_utils;
 pub mod update_command;
+
+use inquire::{
+    validator::{StringValidator, Validation},
+    CustomUserError,
+};
+
+#[derive(Clone)]
+pub struct CommandInputValidator;
+
+impl StringValidator for CommandInputValidator {
+    fn validate(&self, input: &str) -> Result<Validation, CustomUserError> {
+        if input.trim().len() > 0 {
+            Ok(Validation::Valid)
+        } else {
+            Ok(Validation::Invalid("Command must not be empty".into()))
+        }
+    }
+}

--- a/cli/src/command/mod.rs
+++ b/cli/src/command/mod.rs
@@ -14,7 +14,7 @@ pub struct CommandInputValidator;
 
 impl StringValidator for CommandInputValidator {
     fn validate(&self, input: &str) -> Result<Validation, CustomUserError> {
-        if input.trim().len() > 0 {
+        if !input.trim().is_empty() {
             Ok(Validation::Valid)
         } else {
             Ok(Validation::Invalid("Command must not be empty".into()))

--- a/cli/src/command/search_utils.rs
+++ b/cli/src/command/search_utils.rs
@@ -1,7 +1,7 @@
 use crate::{
     args::{PrintStyle, SearchAndPrintArgs},
     outputs::{format_output, spacing},
-    utils::truncate_string,
+    utils::{none_if_empty, truncate_string},
 };
 use cli_clipboard::{ClipboardContext, ClipboardProvider};
 use data::models::Command;
@@ -48,8 +48,8 @@ pub fn get_search_args_from_user() -> Result<SearchArgsUserInput, InquireError> 
     .prompt()?;
 
     Ok(SearchArgsUserInput {
-        command: Some(command),
-        tag: Some(tag),
+        command: none_if_empty(command),
+        tag: none_if_empty(tag),
     })
 }
 

--- a/cli/src/command/update_command.rs
+++ b/cli/src/command/update_command.rs
@@ -2,8 +2,10 @@ use crate::{
     args::SearchAndPrintArgs,
     command::search_utils::{
         check_search_args_exist, fetch_search_candidates, get_search_args_from_user,
-        prompt_user_for_command_selection, SearchArgsUserInput,
+        prompt_user_for_command_selection, FetchSearchCandidatesError,
+        PromptUserForCommandSelectionError, SearchArgsUserInput,
     },
+    command::CommandInputValidator,
     outputs::{format_output, Output},
     utils::none_if_empty,
 };
@@ -12,11 +14,6 @@ use inquire::{InquireError, Select, Text};
 use log::error;
 use logic::Logic;
 use thiserror::Error;
-
-use super::{
-    search_utils::{FetchSearchCandidatesError, PromptUserForCommandSelectionError},
-    CommandInputValidator,
-};
 
 #[derive(Error, Debug)]
 pub enum HandleUpdateError {

--- a/cli/src/command/update_command.rs
+++ b/cli/src/command/update_command.rs
@@ -5,14 +5,18 @@ use crate::{
         prompt_user_for_command_selection, SearchArgsUserInput,
     },
     outputs::{format_output, Output},
+    utils::none_if_empty,
 };
 use data::models::InternalCommand;
-use inquire::{min_length, InquireError, Select, Text};
+use inquire::{InquireError, Select, Text};
 use log::error;
 use logic::Logic;
 use thiserror::Error;
 
-use super::search_utils::{FetchSearchCandidatesError, PromptUserForCommandSelectionError};
+use super::{
+    search_utils::{FetchSearchCandidatesError, PromptUserForCommandSelectionError},
+    CommandInputValidator,
+};
 
 #[derive(Error, Debug)]
 pub enum HandleUpdateError {
@@ -42,7 +46,7 @@ pub fn set_command_properties_wizard(
 ) -> Result<InternalCommand, InquireError> {
     let command = Text::new(&format_output("<bold>Command</bold>:"))
         .with_initial_value(&cur_command.command)
-        .with_validator(min_length!(1, "Command must not be empty"))
+        .with_validator(CommandInputValidator)
         .prompt()?;
 
     let tag = Text::new(&format_output(
@@ -64,8 +68,8 @@ pub fn set_command_properties_wizard(
 
     Ok(InternalCommand {
         command,
-        tag: if !tag.is_empty() { Some(tag) } else { None },
-        note: if !note.is_empty() { Some(note) } else { None },
+        tag: none_if_empty(tag),
+        note: none_if_empty(note),
         favourite,
     })
 }

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -10,8 +10,8 @@ pub fn truncate_string(s: &str, width: usize) -> String {
     }
 }
 
-/// Returns None if the provided string is empty. 
-/// If a string only contains whitespace, None is returned. 
+/// Returns None if the provided string is empty.
+/// If a string only contains whitespace, None is returned.
 pub fn none_if_empty(s: String) -> Option<String> {
     if !s.trim().is_empty() {
         Some(s)

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -10,6 +10,16 @@ pub fn truncate_string(s: &str, width: usize) -> String {
     }
 }
 
+/// Returns None if the provided string is empty. 
+/// If a string only contains whitespace, None is returned. 
+pub fn none_if_empty(s: String) -> Option<String> {
+    if !s.trim().is_empty() {
+        Some(s)
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -27,5 +37,19 @@ mod tests {
         assert_eq!("ab", truncate_string("ab", 3));
         assert_eq!("abc", truncate_string("abc", 3));
         assert_eq!("abcd", truncate_string("abcd", 7));
+    }
+
+    #[test]
+    fn test_none_if_empty() {
+        assert_eq!(none_if_empty("".to_string()), None);
+        assert_eq!(none_if_empty("   ".to_string()), None);
+        assert_eq!(
+            none_if_empty("non-empty".to_string()),
+            Some("non-empty".to_string())
+        );
+        assert_eq!(
+            none_if_empty("  non-empty  ".to_string()),
+            Some("  non-empty  ".to_string())
+        );
     }
 }


### PR DESCRIPTION
Our previous validator would let commands with only whitespace pass (ex. `     `). I had to make a custom validator to ensure we trim the string before checking the length. 