### PR TITLE
Favourite star and selected tag styling

### DIFF
--- a/ui/src/components/ui/tree-view.tsx
+++ b/ui/src/components/ui/tree-view.tsx
@@ -9,7 +9,7 @@ const treeVariants = cva(
 );
 
 const selectedTreeVariants = cva(
-  'before:opacity-100 before:bg-accent text-accent-foreground',
+  'before:opacity-100 before:bg-accent text-accent-foreground before:border-l-4 before:border-primary',
 );
 
 interface TreeDataItem {

--- a/ui/src/components/ui/tree-view.tsx
+++ b/ui/src/components/ui/tree-view.tsx
@@ -9,7 +9,7 @@ const treeVariants = cva(
 );
 
 const selectedTreeVariants = cva(
-  'before:opacity-100 before:bg-accent text-accent-foreground before:border-l-4 before:border-primary',
+  'before:opacity-100 before:bg-accent text-accent-foreground before:border-l-[5px] before:border-primary',
 );
 
 interface TreeDataItem {


### PR DESCRIPTION
Adds a toggle star to the cmd list for favouriting and removes last used from the card:
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/0ccbdc85-05ad-4a3a-9df9-43d2e635696f" />

- favourites always have a visible star
- non-favourite star is only visible on hover and is clickable

also styles the selected tag on the left pane to have a blue indicator:
<img width="240" alt="image" src="https://github.com/user-attachments/assets/983be5c2-7d64-4113-8eff-88278afd4bcb" />

All of this is inspired by postman:
<img width="295" alt="image" src="https://github.com/user-attachments/assets/c21f601b-efc8-4891-90a5-88d8d6ca3691" />

