### PR TITLE
Style command display header and tag improvements

### DIFF
--- a/ui/src/components/command-display.tsx
+++ b/ui/src/components/command-display.tsx
@@ -27,6 +27,9 @@ import { Label } from './ui/label';
 import { Textarea } from './ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { ScrollArea } from './ui/scroll-area';
+import { Badge } from './ui/badge';
+import { cn } from '@/lib/utils';
+import { formatDistanceToNow } from 'date-fns';
 
 interface CommandDisplayProps {
   command: Command | null;
@@ -132,6 +135,8 @@ export function CommandDisplay({ command }: CommandDisplayProps) {
     });
   }
 
+  const tagParts = command?.tag ? command.tag.split('/') : [];
+
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-2">
@@ -141,13 +146,49 @@ export function CommandDisplay({ command }: CommandDisplayProps) {
               <div className="flex items-center p-2">
                 <div className="flex items-center gap-2">
                   <div className="pl-2 font-semibold">
-                    {command.tag ? command.tag : 'Untagged'}
+                    {command.tag &&
+                      tagParts.map((tag, index) => (
+                        <>
+                          <Badge
+                            key={index}
+                            variant={
+                              index == tagParts.length - 1
+                                ? 'default'
+                                : 'outline'
+                            }
+                            className={cn(
+                              index !== tagParts.length - 1 &&
+                                'text-secondary-foreground/40',
+                            )}
+                          >
+                            {tag}
+                          </Badge>
+                          {index !== tagParts.length - 1 && (
+                            <span className="text-xs font-semibold px-1.5">
+                              /
+                            </span>
+                          )}
+                        </>
+                      ))}
                   </div>
                 </div>
                 {command.last_used && (
-                  <div className="ml-auto text-xs text-muted-foreground">
-                    {format(new Date(command.last_used * 1000), 'PPpp')}
-                  </div>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="ml-auto text-xs text-muted-foreground">
+                        Last used&nbsp;
+                        {formatDistanceToNow(
+                          new Date(command.last_used * 1000),
+                          {
+                            addSuffix: true,
+                          },
+                        )}
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {format(new Date(command.last_used * 1000), 'PPp')}
+                    </TooltipContent>
+                  </Tooltip>
                 )}
                 <Separator orientation="vertical" className="mx-2 h-6" />
                 {!editing && (

--- a/ui/src/components/command-display.tsx
+++ b/ui/src/components/command-display.tsx
@@ -153,8 +153,8 @@ export function CommandDisplay({ command }: CommandDisplayProps) {
                             key={index}
                             variant={
                               index == tagParts.length - 1
-                                ? 'default'
-                                : 'outline'
+                                ? 'outline'
+                                : 'secondary'
                             }
                             className={cn(
                               index !== tagParts.length - 1 &&

--- a/ui/src/components/command-list.tsx
+++ b/ui/src/components/command-list.tsx
@@ -42,7 +42,7 @@ export function CommandList({ items }: CommandListProps) {
             </div>
           )}
           <div className="w-full flex items-center gap-2">
-            <Badge key={item.tag} variant={'secondary'}>
+            <Badge key={item.tag} variant={item.tag ? 'secondary' : 'outline'}>
               {item.tag ? item.tag : 'Untagged'}
             </Badge>
             <Star

--- a/ui/src/components/command-list.tsx
+++ b/ui/src/components/command-list.tsx
@@ -42,7 +42,11 @@ export function CommandList({ items }: CommandListProps) {
             </div>
           )}
           <div className="w-full flex items-center gap-2">
-            <Badge key={item.tag} variant={item.tag ? 'secondary' : 'outline'}>
+            <Badge
+              key={item.tag}
+              variant={item.tag ? 'outline' : 'secondary'}
+              className={cn(!item.tag && 'text-secondary-foreground/40')}
+            >
               {item.tag ? item.tag : 'Untagged'}
             </Badge>
             <Star

--- a/ui/src/components/command.tsx
+++ b/ui/src/components/command.tsx
@@ -8,7 +8,7 @@ import { TagTree } from '@/components/tag-tree';
 import { cn } from '@/lib/utils';
 import { Command } from '@/types/command';
 import { useCommand } from '@/use-command';
-import { File, Settings, Star, Tags } from 'lucide-react';
+import { File, ListFilter, Settings, Star, Tags } from 'lucide-react';
 import { useState } from 'react';
 import { AddDialog } from './add-dialog';
 import { SearchForm } from './search-form';
@@ -182,7 +182,8 @@ export function MainCommandPage({
             <SearchForm />
           </div>
           {selectedTagId && (
-            <div className="flex gap-2 px-4 mb-2">
+            <div className="flex gap-2 px-4 mb-2 items-center">
+              <ListFilter size={12} />
               <Badge variant="secondary">{selectedTagId}</Badge>
             </div>
           )}

--- a/ui/src/components/tag-tree.tsx
+++ b/ui/src/components/tag-tree.tsx
@@ -48,20 +48,22 @@ export function TagTree({
     });
 
     const toTreeDataItems = (node: Record<string, TagNode>): TreeDataItem[] => {
-      return Object.values(node).map(({ id, name, children, onClick }) => {
-        const treeDataItem: TreeDataItem = {
-          id,
-          name,
-          onClick,
-        };
+      return Object.values(node)
+        .map(({ id, name, children, onClick }) => {
+          const treeDataItem: TreeDataItem = {
+            id,
+            name,
+            onClick,
+          };
 
-        const childItems = toTreeDataItems(children);
-        if (childItems.length > 0) {
-          treeDataItem.children = childItems;
-        }
+          const childItems = toTreeDataItems(children);
+          if (childItems.length > 0) {
+            treeDataItem.children = childItems;
+          }
 
-        return treeDataItem;
-      });
+          return treeDataItem;
+        })
+        .sort((a, b) => a.name.localeCompare(b.name));
     };
 
     return toTreeDataItems(root);


### PR DESCRIPTION
- styles the selected command's tag in the display pane's header
- changes the last used timestamp to "Last used ... ago" in the display pane's header with a tooltip showing the timestamp (without milliseconds)
- untagged commands in the command list have an outlined tag instead of the usual
- icon beside the selected tag being filtered on
- sorts tags alphabetically at every level of the tree in the tag pane

Before:
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/b2ae75cb-3f5b-4e13-9627-e32d599a9477" />

After:
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/a58eedaf-c1e2-43e6-a45e-b1eeda0a3bb6" />

