### PR TITLE
Implemented feature to execute command in shell upon selection by the user

### DIFF
--- a/cli/src/handlers/cli_prompter.rs
+++ b/cli/src/handlers/cli_prompter.rs
@@ -71,7 +71,7 @@ impl Cli {
         initial_value: &str,
     ) -> Result<String, InquireError> {
         Text::new(&format_output(
-            "<bold>Edit</bold> (Press enter to continue): ",
+            "<bold>Edit</bold> <italics>(Press enter to continue)</italics><bold>:</bold> ",
         ))
         .with_initial_value(initial_value)
         .prompt()

--- a/cli/src/handlers/cli_prompter.rs
+++ b/cli/src/handlers/cli_prompter.rs
@@ -65,6 +65,28 @@ impl Cli {
         })
     }
 
+    /// Prompt user to edit the generated command
+    pub fn prompt_user_for_command_edit(
+        &self,
+        initial_value: &str,
+    ) -> Result<String, InquireError> {
+        Text::new(&format_output(
+            "<bold>Edit</bold> (Press enter to continue): ",
+        ))
+        .with_initial_value(initial_value)
+        .prompt()
+    }
+
+    /// Prompt user to select an action: Copy or Execute
+    pub fn prompt_user_for_action(&self) -> Result<String, InquireError> {
+        Ok(Select::new(
+            &format_output("<bold>Action:</bold>"),
+            vec!["Copy", "Execute"],
+        )
+        .prompt()?
+        .to_owned())
+    }
+
     pub fn prompt_user_for_command_selection(
         &self,
         commands: Vec<Command>,

--- a/cli/src/handlers/search.rs
+++ b/cli/src/handlers/search.rs
@@ -4,6 +4,7 @@ use crate::{
         check_search_args_exist, copy_to_clipboard, CopyTextError,
         PromptUserForCommandSelectionError, SearchArgsUserInput,
     },
+    outputs::spacing,
     Cli,
 };
 use inquire::InquireError;
@@ -52,6 +53,8 @@ impl Cli {
         let (text_to_copy, _) = self
             .logic
             .generate_parameters(user_selection.internal_command.command)?;
+
+        spacing();
 
         // Prompt the user to edit the generated command
         let user_edited_cmd = self.prompt_user_for_command_edit(&text_to_copy)?;

--- a/cli/src/handlers/search.rs
+++ b/cli/src/handlers/search.rs
@@ -9,6 +9,7 @@ use crate::{
 use inquire::InquireError;
 use log::error;
 use logic::command::{SearchCommandArgs, SearchCommandError};
+use std::{os::unix::process::CommandExt, process::Command};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -52,7 +53,22 @@ impl Cli {
             .logic
             .generate_parameters(user_selection.internal_command.command)?;
 
-        copy_to_clipboard(text_to_copy)?;
+        // Prompt the user to edit the generated command
+        let user_edited_cmd = self.prompt_user_for_command_edit(&text_to_copy)?;
+
+        // Prompt the user for command action
+        let action = self.prompt_user_for_action()?;
+
+        if action == "Execute" {
+            // Note: using `.exec()` will shutdown our app and execute the command, therefore, we can't handle errors.
+            let _ = self.logic.update_command_last_used_prop(user_selection.id);
+            let _ = Command::new("sh")
+                .arg("-c")
+                .arg(user_edited_cmd.clone())
+                .exec();
+        }
+
+        copy_to_clipboard(user_edited_cmd)?;
 
         Ok(self
             .logic


### PR DESCRIPTION
This PR adds user functionality to edit your generated command in case you need to apply final touches and then allows the user to select whethere they want to copy it to their clipboard or execute in their terminal. I made the conscious decision here to not support cmd.exe or PowerShell. We need to investigate further whether that's worth the effort. `.exec()` only works for unix-based OS'. Windows does not let you take over a process like Linux does. If you guys have any suggestions, feel free to comment.

Demo for command execution:

https://github.com/user-attachments/assets/b4fa21d0-a0fa-4d9c-a5da-e652f87e6362