### PR TITLE
Created a release pipeline and improved our current CI pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build and Release CLI
+name: Release
 
 on:
     push:
@@ -6,7 +6,7 @@ on:
             - "*"
 
 jobs:
-    build:
+    release-cli:
         runs-on: ubuntu-latest
         permissions:
             contents: write
@@ -14,6 +14,15 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
+
+            - name: Cache Cargo registry and build files
+              uses: actions/cache@v4
+              with:
+                  path: |
+                      ~/.cargo/registry
+                      ~/.cargo/git
+                      target
+                  key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
             - name: Set up Rust toolchain
               uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Build and Release CLI
+
+on:
+    push:
+        tags:
+            - "*"
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Set up Rust toolchain
+              uses: dtolnay/rust-toolchain@stable
+
+            - name: Run Clippy
+              run: cargo clippy --manifest-path cli/Cargo.toml -- -D warnings
+
+            - name: Run Tests
+              run: cargo test --manifest-path cli/Cargo.toml
+
+            - name: Build CLI App
+              run: cargo build --release --manifest-path cli/Cargo.toml
+
+            - name: Upload Release Asset
+              uses: ncipollo/release-action@v1
+              with:
+                  artifacts: target/release/cmdstack

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,105 +1,88 @@
-name: Rust CI
+name: Build & Test
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+    push:
+        branches:
+            - main
+    pull_request:
+        branches:
+            - main
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+    ci:
+        runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
 
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+            - name: Cache Cargo registry and build artifacts
+              uses: actions/cache@v4
+              with:
+                  path: |
+                      ~/.cargo/registry
+                      ~/.cargo/git
+                      target
+                  key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Build
-        run: cargo build --workspace --exclude ui --verbose
+            - name: Set up Rust toolchain
+              uses: dtolnay/rust-toolchain@stable
 
-  test:
-    runs-on: ubuntu-latest
+            - name: Build
+              run: cargo build --workspace --exclude ui --verbose
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+            - name: Clippy
+              run: cargo clippy --workspace --exclude ui --verbose -- -D warnings
 
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+            - name: Test
+              run: cargo test --workspace --exclude ui --verbose
 
-      - name: Test
-        run: cargo test --workspace --exclude ui --verbose
+    # This workflow will build your tauri app without uploading it anywhere.
+    # test-tauri:
+    #   strategy:
+    #     fail-fast: false
+    #     matrix:
+    #       include:
+    #         - platform: "macos-latest" # for Arm based macs (M1 and above).
+    #           args: "--target aarch64-apple-darwin"
+    #         - platform: "macos-latest" # for Intel based macs.
+    #           args: "--target x86_64-apple-darwin"
+    #         - platform: "ubuntu-22.04" # for Tauri v1 you could replace this with ubuntu-20.04.
+    #           args: ""
+    #         - platform: "windows-latest"
+    #           args: ""
 
-  clippy:
-    runs-on: ubuntu-latest
+    #   runs-on: ${{ matrix.platform }}
+    #   steps:
+    #     - uses: actions/checkout@v4
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+    #     - name: setup node
+    #       uses: actions/setup-node@v4
+    #       with:
+    #         node-version: lts/*
 
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+    #     - name: install Rust stable
+    #       uses: dtolnay/rust-toolchain@stable
+    #       with:
+    #         # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
+    #         targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
-      - name: Clippy
-        run: cargo clippy --workspace --exclude ui --verbose -- -D warnings
+    #     - name: install dependencies (ubuntu only)
+    #       if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
+    #       run: |
+    #         sudo apt-get update
+    #         sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+    #       # webkitgtk 4.0 is for Tauri v1 - webkitgtk 4.1 is for Tauri v2.
+    #       # You can remove the one that doesn't apply to your app to speed up the workflow a bit.
 
-  # This workflow will build your tauri app without uploading it anywhere.
-  # test-tauri:
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - platform: "macos-latest" # for Arm based macs (M1 and above).
-  #           args: "--target aarch64-apple-darwin"
-  #         - platform: "macos-latest" # for Intel based macs.
-  #           args: "--target x86_64-apple-darwin"
-  #         - platform: "ubuntu-22.04" # for Tauri v1 you could replace this with ubuntu-20.04.
-  #           args: ""
-  #         - platform: "windows-latest"
-  #           args: ""
+    #     - name: install frontend dependencies
+    #       run: yarn install # change this to npm, pnpm or bun depending on which one you use.
+    #       working-directory: ./ui
 
-  #   runs-on: ${{ matrix.platform }}
-  #   steps:
-  #     - uses: actions/checkout@v4
-
-  #     - name: setup node
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: lts/*
-
-  #     - name: install Rust stable
-  #       uses: dtolnay/rust-toolchain@stable
-  #       with:
-  #         # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
-  #         targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
-
-  #     - name: install dependencies (ubuntu only)
-  #       if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
-  #       run: |
-  #         sudo apt-get update
-  #         sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
-  #       # webkitgtk 4.0 is for Tauri v1 - webkitgtk 4.1 is for Tauri v2.
-  #       # You can remove the one that doesn't apply to your app to speed up the workflow a bit.
-
-  #     - name: install frontend dependencies
-  #       run: yarn install # change this to npm, pnpm or bun depending on which one you use.
-  #       working-directory: ./ui
-
-  #     # If tagName and releaseId are omitted tauri-action will only build the app and won't try to upload any assets.
-  #     - uses: tauri-apps/tauri-action@v0
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         args: ${{ matrix.args }}
-  #         projectPath: ./ui
+    #     # If tagName and releaseId are omitted tauri-action will only build the app and won't try to upload any assets.
+    #     - uses: tauri-apps/tauri-action@v0
+    #       env:
+    #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #       with:
+    #         args: ${{ matrix.args }}
+    #         projectPath: ./ui

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cli"
+name = "cmdstack"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
* Created a new release pipeline. Run the command `git tag v{SEMANTIC_VERSION}` like `git tag v1.0.1-test` to create releases. This will trigger a release for the cli app. It'll be available for us to download.
* Our current CI pipeline would create 3 different jobs with 3 different runners to run build, test and clippy. This was wasting a lot of build minutes. I consolidated that into a single job. I also implemented a cache. Now, if we don't add new packages, it should build very very quickly and save us a lot of build minutes.