### PR TITLE
Added rustfmt to our CI and formatted files to stop inconsistent formatting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
             - name: Run Clippy
               run: cargo clippy --manifest-path cli/Cargo.toml -- -D warnings
 
+            - name: Formatter
+              run: cargo fmt --manifest-path cli/Cargo.toml -- --check
+
             - name: Run Tests
               run: cargo test --manifest-path cli/Cargo.toml
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,6 +34,9 @@ jobs:
             - name: Clippy
               run: cargo clippy --workspace --exclude ui --verbose -- -D warnings
 
+            - name: Formatter
+              run: cargo fmt --all -- --check
+
             - name: Test
               run: cargo test --workspace --exclude ui --verbose
 

--- a/cli/src/handlers/config.rs
+++ b/cli/src/handlers/config.rs
@@ -105,7 +105,9 @@ impl Cli {
     /// Handles the config modification command
     pub fn handle_config_command(&mut self, config_args: ConfigArgs) -> Result<(), ConfigError> {
         match config_args {
-            ConfigArgs::Theme(theme_args) => self.logic.config.application_theme = theme_args.theme.into(),
+            ConfigArgs::Theme(theme_args) => {
+                self.logic.config.application_theme = theme_args.theme.into()
+            }
             ConfigArgs::CliPrintStyle(cli_print_style_args) => {
                 self.logic.config.cli_print_style = cli_print_style_args.style.into()
             }

--- a/cli/src/handlers/mod.rs
+++ b/cli/src/handlers/mod.rs
@@ -1,10 +1,10 @@
 pub mod add;
+pub mod cli_prompter;
 pub mod config;
 pub mod delete;
 pub mod export;
 pub mod import;
 pub mod search;
-pub mod cli_prompter;
 pub mod update;
 
 use inquire::{

--- a/logic/src/config.rs
+++ b/logic/src/config.rs
@@ -37,7 +37,7 @@ pub struct Config {
     pub param_string_length_max: u32,
     pub param_int_range_min: i32,
     pub param_int_range_max: i32,
-    pub application_theme: ApplicationTheme
+    pub application_theme: ApplicationTheme,
 }
 
 impl Default for Config {
@@ -49,7 +49,7 @@ impl Default for Config {
             param_string_length_max: 10,
             param_int_range_min: 5,
             param_int_range_max: 10,
-            application_theme: ApplicationTheme::default()
+            application_theme: ApplicationTheme::default(),
         }
     }
 }


### PR DESCRIPTION
If the formatter fails, run `cargo fmt --all` in your terminal to fix formatting problems.