### PR TITLE
Open command in terminal and generated command styling

### DIFF
--- a/ui/src-tauri/src/lib.rs
+++ b/ui/src-tauri/src/lib.rs
@@ -177,6 +177,30 @@ fn write_config(config: Config, state: State<Ui>) -> Result<(), UiError> {
     Err(UiError::Race)
 }
 
+#[tauri::command]
+fn open_terminal(command: String) {
+    std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(format!(
+            "tell application \"Terminal\" to activate"
+        ))
+        .arg("-e")
+        .arg(format!(
+            "tell application \"System Events\" to keystroke \"{}\"",
+            command
+        ))
+        .spawn()
+        .unwrap();
+}
+
+#[tauri::command]
+fn update_command_last_used(command_id: i64, state: State<Ui>) -> Result<(), UiError> {
+    if let Ok(logic) = state.logic.write() {
+        return Ok(logic.update_command_last_used_prop(command_id)?);
+    }
+    Err(UiError::Race)
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let logic = Logic::try_default()
@@ -197,7 +221,9 @@ pub fn run() {
             update_command,
             search_commands,
             read_config,
-            write_config
+            write_config,
+            update_command_last_used,
+            open_terminal
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/ui/src-tauri/src/lib.rs
+++ b/ui/src-tauri/src/lib.rs
@@ -181,9 +181,7 @@ fn write_config(config: Config, state: State<Ui>) -> Result<(), UiError> {
 fn open_terminal(command: String) {
     std::process::Command::new("osascript")
         .arg("-e")
-        .arg(format!(
-            "tell application \"Terminal\" to activate"
-        ))
+        .arg(format!("tell application \"Terminal\" to activate"))
         .arg("-e")
         .arg(format!(
             "tell application \"System Events\" to keystroke \"{}\"",

--- a/ui/src/components/command-display.tsx
+++ b/ui/src/components/command-display.tsx
@@ -7,7 +7,13 @@ import { useCommands } from '@/use-command';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { invoke } from '@tauri-apps/api/core';
 import format from 'date-fns/format';
-import { Copy, Pencil, RefreshCwIcon, Save } from 'lucide-react';
+import {
+  Copy,
+  Pencil,
+  RefreshCwIcon,
+  Save,
+  SquareTerminal,
+} from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
@@ -127,11 +133,24 @@ export function CommandDisplay({ command }: CommandDisplayProps) {
     }
   }
 
-  function onCopy(e: { preventDefault: () => void }) {
-    e.preventDefault();
+  function onCopy() {
     navigator.clipboard.writeText(generatedCommand);
     toast({
       title: 'Copied to clipboard ✅',
+    });
+
+    invoke('update_command_last_used', {
+      commandId: command?.id,
+    });
+  }
+
+  function onOpenTerminal() {
+    invoke('open_terminal', {
+      command: generatedCommand,
+    });
+
+    invoke('update_command_last_used', {
+      commandId: command?.id,
     });
   }
 
@@ -222,7 +241,52 @@ export function CommandDisplay({ command }: CommandDisplayProps) {
               </div>
               <Separator />
               <div className="flex flex-1 flex-col">
-                <ScrollArea className="h-[calc(100vh-180px)]">
+                <div className="p-4">
+                  <div className="relative w-full">
+                    <Textarea
+                      className="pr-16 bg-accent font-spacemono shadow resize-none"
+                      ref={(textarea) => {
+                        if (textarea) {
+                          textarea.style.height = '0px';
+                          textarea.style.height = textarea.scrollHeight + 'px';
+                        }
+                      }}
+                      value={generatedCommand}
+                      onChange={(e) => setGeneratedCommand(e.target.value)}
+                    />
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          type="button"
+                          disabled={editing}
+                          onClick={onCopy}
+                          className="absolute right-0 top-0 m-2.5 h-4 w-4"
+                        >
+                          <Copy />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Copy command</TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          type="button"
+                          disabled={editing}
+                          onClick={onOpenTerminal}
+                          className="absolute right-8 top-0 m-2.5 h-4 w-4"
+                        >
+                          <SquareTerminal size={16} />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Open in terminal</TooltipContent>
+                    </Tooltip>
+                  </div>
+                </div>
+                <ScrollArea className="h-[calc(100vh-130px)]">
                   <div className="p-4">
                     <FormField
                       control={form.control}
@@ -317,32 +381,6 @@ export function CommandDisplay({ command }: CommandDisplayProps) {
                     )}
                   </div>
                 </ScrollArea>
-                <Separator className="mt-auto" />
-                <div className="px-4">
-                  <div className="flex items-center">
-                    <Label htmlFor="generated-command">Generated Command</Label>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          type="button"
-                          disabled={editing}
-                          onClick={onCopy}
-                        >
-                          <Copy size={12} />
-                        </Button>
-                      </TooltipTrigger>
-                    </Tooltip>
-                  </div>
-                  <div className="grid gap-4">
-                    <Textarea
-                      className="p-4 resize-none"
-                      value={generatedCommand}
-                      disabled={true}
-                    />
-                  </div>
-                </div>
               </div>
             </>
           ) : (

--- a/ui/src/components/command-display.tsx
+++ b/ui/src/components/command-display.tsx
@@ -255,11 +255,12 @@ export function CommandDisplay({ command }: CommandDisplayProps) {
                 <div className="p-4">
                   <div className="relative w-full">
                     <Textarea
-                      className="pr-16 bg-accent font-spacemono shadow resize-none overflow-y-hidden"
+                      className="min-h-0 max-h-[76px] py-[7px] pr-16 bg-accent font-spacemono shadow resize-none"
                       ref={(textarea) => {
                         if (textarea) {
                           textarea.style.height = '0px';
-                          textarea.style.height = textarea.scrollHeight + 'px';
+                          textarea.style.height =
+                            textarea.scrollHeight + 2 + 'px';
                         }
                       }}
                       value={generatedCommand}

--- a/ui/src/components/command-display.tsx
+++ b/ui/src/components/command-display.tsx
@@ -138,6 +138,9 @@ export function CommandDisplay({ command }: CommandDisplayProps) {
       commandId: command?.id,
     }).catch((error) => {
       console.error(error);
+      toast({
+        title: `An error occurred whilst updating metadata. Please refer to logs. ❌`,
+      });
     });
   }
 

--- a/ui/src/components/command-display.tsx
+++ b/ui/src/components/command-display.tsx
@@ -133,25 +133,36 @@ export function CommandDisplay({ command }: CommandDisplayProps) {
     }
   }
 
+  function onUseCommand() {
+    invoke('update_command_last_used', {
+      commandId: command?.id,
+    }).catch((error) => {
+      console.error(error);
+    });
+  }
+
   function onCopy() {
     navigator.clipboard.writeText(generatedCommand);
     toast({
       title: 'Copied to clipboard ✅',
     });
 
-    invoke('update_command_last_used', {
-      commandId: command?.id,
-    });
+    onUseCommand();
   }
 
-  function onOpenTerminal() {
-    invoke('open_terminal', {
+  function onExecuteInTerminal() {
+    invoke('execute_in_terminal', {
       command: generatedCommand,
-    });
-
-    invoke('update_command_last_used', {
-      commandId: command?.id,
-    });
+    })
+      .then(() => {
+        onUseCommand();
+      })
+      .catch((error) => {
+        console.error(error);
+        toast({
+          title: `${error} ❌`,
+        });
+      });
   }
 
   const tagParts = command?.tag ? command.tag.split('/') : [];
@@ -276,13 +287,13 @@ export function CommandDisplay({ command }: CommandDisplayProps) {
                           size="icon"
                           type="button"
                           disabled={editing}
-                          onClick={onOpenTerminal}
+                          onClick={onExecuteInTerminal}
                           className="absolute right-8 top-0 m-2.5 h-4 w-4"
                         >
                           <SquareTerminal size={16} />
                         </Button>
                       </TooltipTrigger>
-                      <TooltipContent>Open in terminal</TooltipContent>
+                      <TooltipContent>Execute in terminal</TooltipContent>
                     </Tooltip>
                   </div>
                 </div>

--- a/ui/src/components/command-display.tsx
+++ b/ui/src/components/command-display.tsx
@@ -244,7 +244,7 @@ export function CommandDisplay({ command }: CommandDisplayProps) {
                 <div className="p-4">
                   <div className="relative w-full">
                     <Textarea
-                      className="pr-16 bg-accent font-spacemono shadow resize-none"
+                      className="pr-16 bg-accent font-spacemono shadow resize-none overflow-y-hidden"
                       ref={(textarea) => {
                         if (textarea) {
                           textarea.style.height = '0px';

--- a/ui/src/components/ui/textarea.tsx
+++ b/ui/src/components/ui/textarea.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 export interface TextareaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
@@ -10,15 +10,15 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
-          className
+          'flex w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+          className,
         )}
         ref={ref}
         {...props}
       />
-    )
-  }
-)
-Textarea.displayName = "Textarea"
+    );
+  },
+);
+Textarea.displayName = 'Textarea';
 
-export { Textarea }
+export { Textarea };

--- a/ui/src/components/ui/textarea.tsx
+++ b/ui/src/components/ui/textarea.tsx
@@ -10,7 +10,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          'flex w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+          'flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
         ref={ref}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -1,60 +1,62 @@
 /** @type {import('tailwindcss').Config} */
-import animate from "tailwindcss-animate";
+import animate from 'tailwindcss-animate';
 
 export default {
-    darkMode: ["class"],
-    content: ["./index.html", "./src/**/*.{ts,tsx,js,jsx}"],
+  darkMode: ['class'],
+  content: ['./index.html', './src/**/*.{ts,tsx,js,jsx}'],
   theme: {
-  	extend: {
-  		borderRadius: {
-  			lg: 'var(--radius)',
-  			md: 'calc(var(--radius) - 2px)',
-  			sm: 'calc(var(--radius) - 4px)'
-  		},
-  		colors: {
-  			background: 'hsl(var(--background))',
-  			foreground: 'hsl(var(--foreground))',
-  			card: {
-  				DEFAULT: 'hsl(var(--card))',
-  				foreground: 'hsl(var(--card-foreground))'
-  			},
-  			popover: {
-  				DEFAULT: 'hsl(var(--popover))',
-  				foreground: 'hsl(var(--popover-foreground))'
-  			},
-  			primary: {
-  				DEFAULT: 'hsl(var(--primary))',
-  				foreground: 'hsl(var(--primary-foreground))'
-  			},
-  			secondary: {
-  				DEFAULT: 'hsl(var(--secondary))',
-  				foreground: 'hsl(var(--secondary-foreground))'
-  			},
-  			muted: {
-  				DEFAULT: 'hsl(var(--muted))',
-  				foreground: 'hsl(var(--muted-foreground))'
-  			},
-  			accent: {
-  				DEFAULT: 'hsl(var(--accent))',
-  				foreground: 'hsl(var(--accent-foreground))'
-  			},
-  			destructive: {
-  				DEFAULT: 'hsl(var(--destructive))',
-  				foreground: 'hsl(var(--destructive-foreground))'
-  			},
-  			border: 'hsl(var(--border))',
-  			input: 'hsl(var(--input))',
-  			ring: 'hsl(var(--ring))',
-  			chart: {
-  				'1': 'hsl(var(--chart-1))',
-  				'2': 'hsl(var(--chart-2))',
-  				'3': 'hsl(var(--chart-3))',
-  				'4': 'hsl(var(--chart-4))',
-  				'5': 'hsl(var(--chart-5))'
-  			}
-  		}
-  	}
+    extend: {
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+      colors: {
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        chart: {
+          1: 'hsl(var(--chart-1))',
+          2: 'hsl(var(--chart-2))',
+          3: 'hsl(var(--chart-3))',
+          4: 'hsl(var(--chart-4))',
+          5: 'hsl(var(--chart-5))',
+        },
+      },
+      fontFamily: {
+        spacemono: ['Space Mono', 'monospace'],
+      },
+    },
   },
   plugins: [animate],
-}
-
+};


### PR DESCRIPTION
moves generated cmd textarea to the top and adds buttons inside it to copy to clipboard and open the command in terminal
- the generated command can be edited in place before copying/opening in terminal
  - I think opening in terminal will only work for mac, it opens a terminal session (or uses an existing one) and types in the command without executing
  - This will require giving the app permission to type
- the text area expands to be multi-line for long commands
- the commands `last_used` is updated when either button is clicked

Before:
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/7e27e5bd-cb75-4a5d-80b3-ef88e822d92d" />

After:
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/f097a42a-c525-402b-89b7-bf428b7b3f87" />


https://github.com/user-attachments/assets/c429beef-69fc-49c9-9aaa-77c997c059c9



