### PR TITLE
Fix CLI blank param indexing

### DIFF
--- a/cli/src/handlers/cli_prompter.rs
+++ b/cli/src/handlers/cli_prompter.rs
@@ -185,15 +185,14 @@ impl Cli {
         &self,
         parsed_params: &[SerializableParameter],
     ) -> Result<Vec<String>, PromptUserForCommandSelectionError> {
+        Output::BlankParameter.print();
+        let mut blank_index = 0;
         let blank_param_values: Vec<String> = parsed_params
             .iter()
-            .enumerate()
-            .filter_map(|(index, param)| match param {
+            .filter_map(|param| match param {
                 SerializableParameter::Blank => {
-                    if index == 0 {
-                        Output::BlankParameter.print();
-                    }
-                    let prompt_text = format!("<bold>Fill in @{{{}}}:</bold>", index + 1);
+                    let prompt_text = format!("<bold>Fill in @{{{}}}:</bold>", blank_index + 1);
+                    blank_index += 1;
                     Some(Text::new(&format_output(&prompt_text)).prompt())
                 }
                 _ => None,


### PR DESCRIPTION
Fixes bug introduced in 33509457c5a2baf37f748f7793a9bfeb64ce414e where blank param fill prompts were being numbered wrong. Also caused the `Fill in blank parameters:` text to not be displayed if there were any params before blank params in the command.

Before:
<img width="766" alt="image" src="https://github.com/user-attachments/assets/00cdad2b-66fa-4736-a994-41bc0af788a4" />

After:
<img width="767" alt="image" src="https://github.com/user-attachments/assets/10753141-a3fd-44d4-b912-02c4a8b64250" />
