### PR TITLE
Fixed the execute-in-terminal arguments bug in cli and added functionality to choose which terminal to execute command in for the GUI

### DIFF
--- a/cli/src/handlers/config.rs
+++ b/cli/src/handlers/config.rs
@@ -32,6 +32,9 @@ pub enum ConfigArgs {
 
     /// Modify application theme
     Theme(ApplicationThemeArgs),
+
+    /// Modify default terminal used in the UI to execute commands in
+    UiDefaultTerminal(UiDefaultTerminalArgs),
 }
 
 #[derive(Debug, Args)]
@@ -66,11 +69,24 @@ pub struct CliDisplayLimitArgs {
     pub value: u32,
 }
 
+#[derive(Debug, Args)]
+#[command(arg_required_else_help(true))]
+pub struct UiDefaultTerminalArgs {
+    pub terminal_name: UiDefaultTerminal,
+}
+
 #[derive(Debug, Clone, ValueEnum, Serialize, Deserialize, Default)]
 pub enum CliPrintStyle {
     #[default]
     All,
     CommandsOnly,
+}
+
+#[derive(Debug, Clone, ValueEnum, Serialize, Deserialize, Default)]
+pub enum UiDefaultTerminal {
+    Iterm,
+    #[default]
+    Terminal,
 }
 
 #[derive(Debug, Args, Validate)]
@@ -137,9 +153,9 @@ impl Cli {
 
                 if min > max {
                     return Err(ConfigError::InvalidValue(format!(
-                        "param-string-length-min ({}) cannot be greater than param-string-length-max ({})",
-                        min, max
-                    )));
+                                "param-string-length-min ({}) cannot be greater than param-string-length-max ({})",
+                                min, max
+                            )));
                 }
 
                 self.logic.config.param_string_length_min = min;
@@ -170,6 +186,9 @@ impl Cli {
                 self.logic.config.param_int_range_min = min;
                 self.logic.config.param_int_range_max = max;
             }
+            ConfigArgs::UiDefaultTerminal(ui_default_terminal_args) => {
+                self.logic.config.default_terminal = ui_default_terminal_args.terminal_name.into();
+            }
         }
         Ok(self.logic.config.write()?)
     }
@@ -190,6 +209,15 @@ impl From<ApplicationTheme> for logic::config::ApplicationTheme {
             ApplicationTheme::System => Self::System,
             ApplicationTheme::Dark => Self::Dark,
             ApplicationTheme::Light => Self::Light,
+        }
+    }
+}
+
+impl From<UiDefaultTerminal> for logic::config::UiDefaultTerminal {
+    fn from(item: UiDefaultTerminal) -> Self {
+        match item {
+            UiDefaultTerminal::Iterm => Self::Iterm,
+            UiDefaultTerminal::Terminal => Self::Terminal,
         }
     }
 }

--- a/logic/src/config.rs
+++ b/logic/src/config.rs
@@ -38,6 +38,7 @@ pub struct Config {
     pub param_int_range_min: i32,
     pub param_int_range_max: i32,
     pub application_theme: ApplicationTheme,
+    pub default_terminal: UiDefaultTerminal,
 }
 
 impl Default for Config {
@@ -50,6 +51,7 @@ impl Default for Config {
             param_int_range_min: 5,
             param_int_range_max: 10,
             application_theme: ApplicationTheme::default(),
+            default_terminal: UiDefaultTerminal::default(),
         }
     }
 }
@@ -67,6 +69,13 @@ pub enum CliPrintStyle {
     #[default]
     All,
     CommandsOnly,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, Copy, PartialEq)]
+pub enum UiDefaultTerminal {
+    Iterm,
+    #[default]
+    Terminal,
 }
 
 impl Config {

--- a/ui/src/types/config.tsx
+++ b/ui/src/types/config.tsx
@@ -1,20 +1,26 @@
 export enum CliPrintStyle {
-    All = "All",
-    CommandsOnly = "CommandsOnly",
-};
+  All = 'All',
+  CommandsOnly = 'CommandsOnly',
+}
 
 export enum ApplicationTheme {
-    Dark = "Dark",
-    Light = "Light",
-    System = "System"
-};
+  Dark = 'Dark',
+  Light = 'Light',
+  System = 'System',
+}
+
+export enum DefaultTerminal {
+  Iterm = 'Iterm',
+  Terminal = 'Terminal',
+}
 
 export type SettingsConfig = {
-    cli_print_style: CliPrintStyle,
-    cli_display_limit: number,
-    param_string_length_min: number,
-    param_string_length_max: number,
-    param_int_range_min: number,
-    param_int_range_max: number,
-    application_theme: ApplicationTheme
+  cli_print_style: CliPrintStyle;
+  cli_display_limit: number;
+  param_string_length_min: number;
+  param_string_length_max: number;
+  param_int_range_min: number;
+  param_int_range_max: number;
+  application_theme: ApplicationTheme;
+  default_terminal: DefaultTerminal;
 };


### PR DESCRIPTION
This PR does a few things:
1. Previously, the execute-in-terminal for the cli had a bug where not all command arguments would be provided. The output was also not printing. This is now fixed.
2. Added a new config key ui-default-terminal to allow the user to pick their default terminal app to execute commands in from the ui.
3. Added iTerm2 as an option to execute commands in. Default option is still Terminal, but can be easily changed to iTerm using the `cmdstack config ui-default-terminal iterm` command. 
