### PR TITLE
Sort commands and styling

### DIFF
--- a/ui/src/components/add-form.tsx
+++ b/ui/src/components/add-form.tsx
@@ -80,6 +80,7 @@ export function AddForm({ onSuccess }: AddFormProps) {
               <FormControl>
                 <Input
                   placeholder="INSERT INTO users VALUES (@{string[5,10]}, @{int});"
+                  className="font-robotomono"
                   {...field}
                 />
               </FormControl>

--- a/ui/src/components/command-display/command-display.tsx
+++ b/ui/src/components/command-display/command-display.tsx
@@ -391,7 +391,7 @@ export function CommandDisplay({ command }: CommandDisplayProps) {
                             <Textarea
                               className={cn(
                                 !editing.command && 'border-none shadow-none',
-                                'min-h-0 py-[7px] font-robotomono resize-none',
+                                'min-h-0 py-[7px] font-robotomono resize-none disabled:cursor-auto',
                               )}
                               ref={(textarea) => {
                                 fieldRef(textarea);
@@ -419,23 +419,28 @@ export function CommandDisplay({ command }: CommandDisplayProps) {
                   <div className="p-4">
                     {parameters.length > 0 && !editing.command && (
                       <>
-                        <div className="flex items-center">
+                        <div className="flex items-center h-9">
                           <Label htmlFor="parameters">Parameters</Label>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                type="button"
-                                onClick={onParameterRefresh}
-                              >
-                                <RefreshCwIcon size={12} />
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              Regenerate Parameters
-                            </TooltipContent>
-                          </Tooltip>
+                          {/* Only allow regenerating parameters if there are non-blank parameters */}
+                          {parameters.some(
+                            (p) => p.type !== ParameterType.Blank,
+                          ) && (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  type="button"
+                                  onClick={onParameterRefresh}
+                                >
+                                  <RefreshCwIcon size={12} />
+                                </Button>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                Regenerate Parameters
+                              </TooltipContent>
+                            </Tooltip>
+                          )}
                         </div>
                         <ParamViewer
                           parameters={parameters}

--- a/ui/src/components/command.tsx
+++ b/ui/src/components/command.tsx
@@ -9,7 +9,7 @@ import { cn } from '@/lib/utils';
 import { Command } from '@/types/command';
 import { useCommand } from '@/use-command';
 import { File, ListFilter, Star, Tags } from 'lucide-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { AddDialog } from './add-dialog';
 import { SearchForm } from './search-form';
 import { SettingsDialog } from './settings/settings-dialog';
@@ -50,11 +50,15 @@ export function MainCommandPage({
     setSelectedTagId(undefined);
   };
 
+  const sortedCommands = useMemo(() => {
+    return [...commands].sort((a, b) => (a.last_used > b.last_used ? -1 : 1));
+  }, [commands]);
+
   const tagFilteredCommands = selectedTagId
-    ? commands.filter(
+    ? sortedCommands.filter(
         (command) => command.tag && command.tag.startsWith(selectedTagId),
       )
-    : commands;
+    : sortedCommands;
 
   return (
     <TooltipProvider delayDuration={0}>
@@ -160,7 +164,7 @@ export function MainCommandPage({
           className="flex h-screen flex-col min-w-[290px]"
         >
           <div className="flex items-center pl-4 pr-2 py-2">
-            <h1 className="text-xl font-bold">Commands</h1>
+            <h1 className="text-xl font-bold cursor-default">Commands</h1>
             <div className="ml-auto">
               <AddDialog />
             </div>

--- a/ui/src/page.tsx
+++ b/ui/src/page.tsx
@@ -10,7 +10,7 @@ export default function CommandPage() {
 
   return (
     <>
-      <div className="hidden flex-col md:flex">
+      <div className="hidden flex-col md:flex select-none">
         <MainCommandPage
           commands={commands ? commands : []}
           defaultLayout={defaultLayout}


### PR DESCRIPTION
- sorts commands in the list by last used (which also means new commands go on top since new commands have `now` last used so it's actually a stack)
- random styling things
  - disallow selecting app text (can't ctrl-a to highlight the whole page)
  - fix some cursor types
  - remove regenerate button when there are only blank params
  - match add command box font to command display (roboto)