### PR TITLE
Fix "No Commands Found" printing bug

### DIFF
--- a/cli/src/handlers/search.rs
+++ b/cli/src/handlers/search.rs
@@ -51,6 +51,9 @@ impl Cli {
             order_by_recently_used: args.order_by_recently_used,
             favourites_only: args.favourite,
         })?;
+        if search_results.is_empty() {
+            return Err(HandleSearchError::NoCommandFound);
+        }
 
         let user_selection = self.prompt_user_for_command_selection(search_results)?;
 

--- a/cli/src/handlers/update.rs
+++ b/cli/src/handlers/update.rs
@@ -86,6 +86,9 @@ impl Cli {
             order_by_recently_used: args.order_by_recently_used,
             favourites_only: args.favourite,
         })?;
+        if search_results.is_empty() {
+            return Err(HandleUpdateError::NoCommandFound);
+        }
 
         let user_selection = self.prompt_user_for_command_selection(search_results)?;
 


### PR DESCRIPTION
When calling `update` and `search`, if the search yielded no commands, the following would be printed instead of "No Command Found".

<img width="1060" alt="bug" src="https://github.com/user-attachments/assets/f5ffc510-3d6a-401b-9283-4f7519d279ff" />

This PR fixes this bug. 


