### PR TITLE
Disable autocaps on fields

### DIFF
--- a/ui/src/components/add-form.tsx
+++ b/ui/src/components/add-form.tsx
@@ -81,6 +81,8 @@ export function AddForm({ onSuccess }: AddFormProps) {
                 <Input
                   placeholder="INSERT INTO users VALUES (@{string[5,10]}, @{int});"
                   className="font-robotomono"
+                  autoCapitalize="off"
+                  autoCorrect="off"
                   {...field}
                 />
               </FormControl>
@@ -96,7 +98,12 @@ export function AddForm({ onSuccess }: AddFormProps) {
             <FormItem>
               <FormLabel>Tag</FormLabel>
               <FormControl>
-                <Input placeholder="SQL/INSERT" {...field} />
+                <Input
+                  placeholder="SQL/INSERT"
+                  autoCapitalize="off"
+                  autoCorrect="off"
+                  {...field}
+                />
               </FormControl>
               <FormDescription>
                 This is your tag for the command.

--- a/ui/src/components/command-display/command-display.tsx
+++ b/ui/src/components/command-display/command-display.tsx
@@ -255,6 +255,8 @@ export function CommandDisplay({ command }: CommandDisplayProps) {
                                     fieldRef(input);
                                     tagRef.current = input;
                                   }}
+                                  autoCapitalize="off"
+                                  autoCorrect="off"
                                 />
                               </FormControl>
                               <FormMessage />
@@ -406,6 +408,8 @@ export function CommandDisplay({ command }: CommandDisplayProps) {
                                 editing.command ? fieldValue : indexedCommand
                               }
                               disabled={!editing.command}
+                              autoCapitalize="off"
+                              autoCorrect="off"
                               {...rest}
                             />
                           </FormControl>

--- a/ui/src/components/command-display/use-command-box.tsx
+++ b/ui/src/components/command-display/use-command-box.tsx
@@ -66,6 +66,8 @@ export function UseCommandBox({
         }}
         value={command}
         onChange={onChangeCommand}
+        autoCapitalize="off"
+        autoCorrect="off"
       />
       <Tooltip>
         <TooltipTrigger asChild>


### PR DESCRIPTION
Removes these suggestions for all non-note fields:
<img width="503" alt="image" src="https://github.com/user-attachments/assets/f09cb5f6-50fb-487e-a3a6-f96e4ba224d9" />